### PR TITLE
Support for Chroma

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,8 @@ elif [[ -e /dev/input/by-id/usb-Razer_Razer_Naga_2014-if02-event-kbd ]]; then
 elif [[ -e /dev/input/by-id/usb-Razer_Razer_Naga-if01-event-kbd ]]; then
 	version=molten
 elif [[ -e /dev/input/by-id/usb-Razer_Razer_Naga_Epic_Chroma-if01-event-kbd ]]; then
+	version=epic-chroma
+elif [[ -e /dev/input/by-id/usb-Razer_Razer_Naga_Chroma-if02-event-kbd ]]; then
 	version=chroma
 else 
 	echo "Naga not connected or using unsupported model. Please check src/naga.cpp and nagastart.sh. Daemon will not autostart."

--- a/src/naga.cpp
+++ b/src/naga.cpp
@@ -23,10 +23,11 @@
 using namespace std;
 
 const char *devices[][2] = {
-        {"/dev/input/by-id/usb-Razer_Razer_Naga_Epic-if01-event-kbd",        "/dev/input/by-id/usb-Razer_Razer_Naga_Epic-event-mouse"},       // NAGA EPIC
-        {"/dev/input/by-id/usb-Razer_Razer_Naga_2014-if02-event-kbd",        "/dev/input/by-id/usb-Razer_Razer_Naga_2014-event-mouse"},       // NAGA 2014
-        {"/dev/input/by-id/usb-Razer_Razer_Naga-if01-event-kbd",             "/dev/input/by-id/usb-Razer_Razer_Naga-event-mouse"},            // NAGA MOLTEN
-        {"/dev/input/by-id/usb-Razer_Razer_Naga_Epic_Chroma-if01-event-kbd", "/dev/input/by-id/usb-Razer_Razer_Naga_Epic_Chroma-event-mouse"} // NAGA EPIC CHROMA
+        {"/dev/input/by-id/usb-Razer_Razer_Naga_Epic-if01-event-kbd",        "/dev/input/by-id/usb-Razer_Razer_Naga_Epic-event-mouse"},        // NAGA EPIC
+        {"/dev/input/by-id/usb-Razer_Razer_Naga_2014-if02-event-kbd",        "/dev/input/by-id/usb-Razer_Razer_Naga_2014-event-mouse"},        // NAGA 2014
+        {"/dev/input/by-id/usb-Razer_Razer_Naga-if01-event-kbd",             "/dev/input/by-id/usb-Razer_Razer_Naga-event-mouse"},             // NAGA MOLTEN
+        {"/dev/input/by-id/usb-Razer_Razer_Naga_Epic_Chroma-if01-event-kbd", "/dev/input/by-id/usb-Razer_Razer_Naga_Epic_Chroma-event-mouse"}, // NAGA EPIC CHROMA
+        {"/dev/input/by-id/usb-Razer_Razer_Naga_Chroma-if02-event-kbd",      "/dev/input/by-id/usb-Razer_Razer_Naga_Chroma-event-mouse"}  // NAGA CHROMA
 };
 
 class NagaDaemon {
@@ -42,7 +43,7 @@ public:
         this->loadConf("mapping_01.txt");
         //Setup check
         if (argv[1] == NULL) {
-            cout << "Missing parameter: type. Possible parameters: epic, 2014, molten, chroma." << endl << "Example usage: $ naga epic" << endl;
+            cout << "Missing parameter: type. Possible parameters: epic, 2014, molten, epic-chroma, chroma." << endl << "Example usage: $ naga epic" << endl;
             exit(0);
         }
         if ((string) argv[1] == "epic")
@@ -51,8 +52,10 @@ public:
             id = 1;
         else if ((string) argv[1] == "molten")
             id = 2;
-        else if ((string) argv[1] == "chroma")
+        else if ((string) argv[1] == "epic-chroma")
             id = 3;
+        else if ((string) argv[1] == "chroma")
+            id = 4;
         else {
             cerr << "Not a valid device. Exiting." << endl;
             exit(1);


### PR DESCRIPTION
Hello all.

First and foremost thanks for developing this tool.

I want support for Naga Chroma so I added a few lines to do that according to the documentation. However, I found that `chroma` was applied to "Epic Chroma". I take the liberty to change the identifier for Epic Chroma to `epic-chroma` and leave `chroma` for "Chroma". As I can understand, this maybe will create issues for users of Epic Chroma so feel free to discard that thing, it is only a suggestion.

One thing I changed without understand what happened was the use of `if02` instead of `if01`. I did that change because the variant with `if01` didn't work. I'm open to provide more information if you can guide me what to do.

I'm running Manjaro (Arch Linux based distro) and I've tested the default configuration without errors.

If I can help more please tell me.