### PR TITLE
Added option for media buttons

### DIFF
--- a/src/naga.cpp
+++ b/src/naga.cpp
@@ -98,6 +98,7 @@ public:
                 std::replace(line.begin(), line.end(), ',', ' ');
             }
             else if (token2 == "delay") options[pos].push_back(7);
+            else if (token2 == "media") options[pos].push_back(8);
             else {
                 cerr << "Not supported key action, check the syntax in " << conf_file << ". Exiting!" << endl;
                 exit(1);
@@ -203,6 +204,9 @@ public:
                     delay = stoi(args[i][j]) * 1000;
                     usleep(delay);
                     execution = false;
+                    break;
+                case 8: //media options
+                    command = "xdotool key XF86" + args[i][j] + " ";
                     break;
             }
             if (execution)


### PR DESCRIPTION
There are some missing keys such as play, pause, previous and next. This aims to fix that. I've added a new option named __media__. This option takes the following inputs.

| Function  | Input |
| ------------- | ------------- |
| Play/Pause  | `AudioPlay`  |
| Previous/Next  | `AudioPrev` / `XF86AudioNext`  |
| Volume Up/Down | `AudioLowerVolume` / `AudioRaiseVolume` | 
| Mute | `AudioMute` |

## Example usage: 

```
7 - media=AudioMute
8 - media=AudioLowerVolume
9 - media=AudioRaiseVolume
10 - media=AudioPrev
11 - media=AudioPlay
12 - media=AudioNext
```